### PR TITLE
Feat: Finnhub MCP Tools 구축 및 Supabase Vector Store 설정

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,24 +2,23 @@
 
 ## Data Layer
 
-### Finnhub Client
+### Finnhub MCP Server (Tools)
+`src.tools.finnhub_server`
 
-`src.data.finnhub_client.FinnhubClient`
+Implements Model Context Protocol (MCP) tools for real-time market data.
 
-Handles interaction with Finnhub API for real-time market data.
-
-```python
-from src.data.finnhub_client import get_finnhub_client
-
-client = get_finnhub_client()
+**Run Server:**
+```bash
+python src/tools/finnhub_server.py
 ```
 
-#### Key Methods
-
-- `get_quote(symbol: str) -> dict`: Get real-time price data (Open, High, Low, Close).
-- `get_company_profile(symbol: str) -> dict`: Get company metadata (Sector, Market Cap).
-- `get_company_news(symbol: str, ...) -> list`: Get recent market news.
-- `get_financial_metrics(symbol: str) -> dict`: Get basic financial ratios.
+#### Available Tools
+- **`get_stock_quote(symbol)`**: Returns real-time price info (c, h, l, o, pc).
+  - *Example Return*: `{"current_price": 150.5, "change": 2.1, ...}`
+- **`get_company_profile(symbol)`**: Returns industry, market cap, and IPO details.
+- **`get_price_target(symbol)`**: Returns analyst consensus and price targets.
+- **`get_company_news(symbol, from_date, to)`**: Fetches company-specific news.
+- **`get_market_news(category)`**: Fetches general market news.
 
 ### Supabase Client
 

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -24,11 +24,14 @@
 - **데이터**: Supabase `company_relationships` 테이블 활용.
 - **UI**: Interactive Graph Visualization.
 
-### 4. **실시간 데이터 통합** 📈
-
-- **Source**: **Finnhub API** 단일화 (기존 RapidAPI 대체).
-- **데이터**: 실시간 주가(Quote), 시장 뉴스, 재무 지표(Metrics).
-- **안정성**: API 에러 핸들링 및 유효성 검사 강화.
+### 4. **실시간 데이터 통합 (via MCP)** 🔌
+- **아키텍처**: **MCP (Model Context Protocol)** 기반의 Tools 서버 구축.
+- **Tools**:
+  - `get_stock_quote`: 실시간 주가 조회
+  - `get_company_profile`: 기업 프로필 조회
+  - `get_price_target`: 투자의견 및 목표주가
+  - `get_company_news`: 관련 뉴스 검색
+- **장점**: 에이전트(LangGraph/LLM)가 필요 시 **스스로 도구를 호출(Tool Calling)**하여 최신 데이터 획득.
 
 ---
 

--- a/scripts/test_mcp_client.py
+++ b/scripts/test_mcp_client.py
@@ -1,0 +1,50 @@
+"""
+MCP 클라이언트 테스트 스크립트
+Claude Desktop 없이 Python 코드에서 직접 MCP 서버를 실행하고 툴을 호출합니다.
+"""
+
+import asyncio
+import os
+import sys
+
+# 프로젝트 루트 경로 추가
+sys.path.append(os.getcwd())
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+async def main():
+    print("🔌 Finnhub MCP 서버에 연결 중...")
+    
+    # 1. MCP 서버 실행 파라미터 설정
+    server_params = StdioServerParameters(
+        command="python", # 현재 환경의 python 사용
+        args=["src/tools/finnhub_server.py"],
+        env=os.environ.copy() # 현재 환경 변수(.env 포함) 전달
+    )
+
+    # 2. 서버 연결 및 세션 시작
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            # 초기화
+            await session.initialize()
+            
+            # 3. 사용 가능한 툴 목록 조회
+            tools = await session.list_tools()
+            print(f"\n🛠️  발견된 툴 ({len(tools.tools)}개):")
+            for tool in tools.tools:
+                print(f"   - {tool.name}: {tool.description[:50]}...")
+            
+            # 4. 툴 호출 테스트 (애플 주가 조회)
+            print("\n📈 'get_stock_quote' 툴 호출 (Symbol: AAPL)...")
+            result = await session.call_tool("get_stock_quote", arguments={"symbol": "AAPL"})
+            
+            # 5. 결과 출력
+            print("\n📊 결과 확인:")
+            if result.content:
+                print(result.content[0].text)
+            else:
+                print("결과 없음")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/tools/finnhub_server.py
+++ b/src/tools/finnhub_server.py
@@ -1,0 +1,116 @@
+"""
+Finnhub MCP Server
+Finnhub API를 사용하여 주식 시장 데이터를 제공하는 MCP 서버입니다.
+"""
+
+from typing import Optional, List, Dict, Any
+import os
+import finnhub
+from mcp.server.fastmcp import FastMCP
+from dotenv import load_dotenv
+
+# 환경 변수 로드
+load_dotenv()
+
+# API 키 확인
+API_KEY = os.getenv("FINNHUB_API_KEY")
+if not API_KEY:
+    raise ValueError("FINNHUB_API_KEY가 환경 변수(.env)에 설정되지 않았습니다.")
+
+# Finnhub 클라이언트 초기화
+finnhub_client = finnhub.Client(api_key=API_KEY)
+
+# MCP 서버 초기화
+mcp = FastMCP("Finnhub Stock Data")
+
+@mcp.tool()
+def get_stock_quote(symbol: str) -> Dict[str, Any]:
+    """
+    특정 주식 티커의 실시간 시세 정보를 조회합니다.
+    
+    Args:
+        symbol: 주식 티커 (예: AAPL, TSLA)
+        
+    Returns:
+        현재가(c), 전일종가(pc), 시가(o), 고가(h), 저가(l), 등락률(dp) 등을 포함한 딕셔너리
+    """
+    try:
+        quote = finnhub_client.quote(symbol)
+        
+        # 보기 쉽게 키 매핑 (선택 사항)
+        return {
+            "symbol": symbol,
+            "current_price": quote.get("c"),
+            "change": quote.get("d"),
+            "percent_change": quote.get("dp"),
+            "high": quote.get("h"),
+            "low": quote.get("l"),
+            "open": quote.get("o"),
+            "previous_close": quote.get("pc"),
+            "timestamp": quote.get("t")
+        }
+    except Exception as e:
+        return {"error": str(e), "symbol": symbol}
+
+@mcp.tool()
+def get_company_profile(symbol: str) -> Dict[str, Any]:
+    """
+    기업의 기본 프로필 정보(산업, 시가총액, 웹사이트 등)를 조회합니다.
+    
+    Args:
+        symbol: 주식 티커
+    """
+    try:
+        profile = finnhub_client.company_profile2(symbol=symbol)
+        return profile
+    except Exception as e:
+        return {"error": str(e), "symbol": symbol}
+
+@mcp.tool()
+def get_price_target(symbol: str) -> Dict[str, Any]:
+    """
+    애널리스트들의 목표 주가 및 투자의견 컨센서스를 조회합니다.
+    
+    Args:
+        symbol: 주식 티커
+    """
+    try:
+        target = finnhub_client.price_target(symbol)
+        return target
+    except Exception as e:
+        return {"error": str(e), "symbol": symbol}
+
+@mcp.tool()
+def get_company_news(symbol: str, from_date: str, to: str) -> List[Dict[str, Any]]:
+    """
+    특정 기업의 관련 뉴스를 조회합니다.
+    
+    Args:
+        symbol: 주식 티커
+        from_date: 시작 날짜 (YYYY-MM-DD)
+        to: 종료 날짜 (YYYY-MM-DD)
+    """
+    try:
+        # API 호출 시 파라미터 이름 매핑 (_from)
+        news = finnhub_client.company_news(symbol, _from=from_date, to=to)
+        return news[:10]  # 최근 10개만 반환
+    except Exception as e:
+        return [{"error": str(e), "symbol": symbol}]
+
+@mcp.tool()
+def get_market_news(category: str = "general") -> List[Dict[str, Any]]:
+    """
+    시장 전체 뉴스를 조회합니다.
+    
+    Args:
+        category: 뉴스 카테고리 (general, forex, crypto, merger)
+    """
+    try:
+        news = finnhub_client.general_news(category, min_id=0)
+        return news[:10]
+    except Exception as e:
+        return [{"error": str(e)}]
+
+if __name__ == "__main__":
+    # MCP 서버 실행
+    mcp.run()


### PR DESCRIPTION
# 🚀 feat: MCP 기반 실시간 데이터 툴 & Vector Store 구축

## 📋 개요
이 PR은 실시간 시장 데이터 수집을 위한 **MCP(Model Context Protocol)** 서버를 구축하고, RAG(검색 증강 생성)를 위한 **Supabase Vector Store** 인프라를 완성합니다. 에이전트가 필요할 때 스스로 호출할 수 있는 강력한 도구들을 추가했습니다.

## 🛠️ 주요 변경 사항

### 1. 🔌 Finnhub MCP Server (`src/tools/`)
- **MCP(Model Context Protocol)** 표준을 준수하는 Tool 서버 구현.
- **제공되는 도구 (Tools)**:
  - `get_stock_quote(symbol)`: 실시간 주가, 변동률, 시가/고가/저가 조회.
  - `get_company_profile(symbol)`: 시가총액, 산업 분야 등 기업 기본 정보.
  - `get_price_target(symbol)`: 애널리스트 목표 주가 및 의견.
  - `get_company_news(symbol, from_date, to)`: 특정 기업 뉴스 검색.
  - `get_market_news(category)`: 일반 시장 뉴스.
- **특징**: `FastMCP`를 사용하여 경량화되었으며, Python 환경에서 직접 호출 가능 (`stdio`).

### 2. 🧠 Vector Store & Embedding (`scripts/`, `sql/`)
- **Supabase pgvector 설정**:
  - `sql/vector_store.sql`: 문서 저장용 테이블(`documents`) 및 벡터 검색 함수(`match_documents`) 추가.
- **임베딩 파이프라인**:
  - `scripts/embed_10k_documents.py`: 수집된 10-K 텍스트를 `text-embedding-3-small` 모델로 임베딩하여 DB에 적재.
  - 청크(Chunk) 단위 분할 및 메타데이터(섹션명, 출처) 보존.

### 3. 🧪 테스트 및 유틸리티
- `scripts/test_mcp_client.py`: Claude Desktop 없이도 Python 코드로 MCP 툴을 테스트할 수 있는 클라이언트 구현.
- `.gitignore`: 데이터 및 캐시 파일 제외 규칙 최적화 (`/data/`).

## 📚 문서화
- `PROJECT_SUMMARY.md`: 실시간 데이터 통합 방식을 MCP 아키텍처로 업데이트.
- `API.md`: Finnhub Client 섹션을 MCP Server Tools 명세로 대체.

## ✅ 테스트 방법

1. **환경 변수 확인**: `.env`에 `FINNHUB_API_KEY`, `OPENAI_API_KEY`, `SUPABASE_URL/KEY`가 설정되어 있어야 합니다.
2. **MCP 서버 테스트**:
   ```bash
   python scripts/test_mcp_client.py
   # 결과: Apple(AAPL)의 현재 주가가 출력되면 성공