### PR TITLE
feat(api): Stock API로 리팩토링 및 yfinance fallback 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ SKN22-3rd-4Team/
 ├── models/
 │   └── settings.py           # AI Model Configs
 ├── src/
-│   ├── data/                 # Finnhub & Supabase Clients
+│   ├── data/                 # Stock API (Finnhub + yfinance) & Supabase Clients
 │   ├── rag/                  # Analyst Chat, Report Gen, GraphRAG
 │   ├── ui/                   # Streamlit Pages
 │   └── utils/
@@ -100,7 +100,10 @@ streamlit run app.py
 | :--- | :--- | :--- |
 | **Supabase** | 재무제표 DB & Vector Store | ✅ 연동 완료 |
 | **Finnhub** | 실시간 주가, 뉴스, 재무 지표 | ✅ 연동 완료 |
+| **yfinance** | 주가 추이, 목표주가 (Finnhub fallback) | ✅ 연동 완료 |
 | **OpenAI** | LLM (Chat, Report, SQL) | ✅ 연동 완료 |
+
+> **Note**: Finnhub 무료 플랜에서 제한되는 `stock/candle`(주가 추이), `stock/price-target`(목표주가)은 yfinance로 자동 fallback됩니다.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,5 @@ matplotlib>=3.8.2
 plotly>=5.18.0
 reportlab>=4.0.0
 finnhub-python>=2.4.19
+yfinance>=0.2.36
 pytz>=2024.1

--- a/src/rag/rag_base.py
+++ b/src/rag/rag_base.py
@@ -33,18 +33,18 @@ except ImportError:
         RAG_AVAILABLE = False
         logger.warning("RAG core modules not found. Some features may be disabled.")
 
-# Finnhub 클라이언트 임포트
+# Stock API 클라이언트 임포트
 try:
-    from data.finnhub_client import get_finnhub_client
+    from data.stock_api_client import get_stock_api_client
 
-    FINNHUB_AVAILABLE = True
+    STOCK_API_AVAILABLE = True
 except ImportError:
     try:
-        from src.data.finnhub_client import get_finnhub_client
+        from src.data.stock_api_client import get_stock_api_client
 
-        FINNHUB_AVAILABLE = True
+        STOCK_API_AVAILABLE = True
     except ImportError:
-        FINNHUB_AVAILABLE = False
+        STOCK_API_AVAILABLE = False
 
 # 환율 클라이언트 임포트
 try:
@@ -79,15 +79,15 @@ class RAGBase:
             raise ValueError("SUPABASE_URL과 SUPABASE_KEY 환경 변수가 필요합니다.")
         self.supabase: Client = create_client(supabase_url, supabase_key)
 
-        # 3. Finnhub 초기화
+        # 3. Stock API 초기화
         self.finnhub = None
-        if FINNHUB_AVAILABLE:
+        if STOCK_API_AVAILABLE:
             try:
-                self.finnhub = get_finnhub_client()
+                self.finnhub = get_stock_api_client()
                 if not self.finnhub.api_key:
                     self.finnhub = None
             except Exception as e:
-                logger.warning(f"Finnhub init failed: {e}")
+                logger.warning(f"Stock API init failed: {e}")
 
         # 4. RAG 엔진 초기화
         self.vector_store = None

--- a/src/tools/stock_api_server.py
+++ b/src/tools/stock_api_server.py
@@ -1,6 +1,6 @@
 """
-Finnhub MCP Server
-Finnhub API를 사용하여 주식 시장 데이터를 제공하는 MCP 서버입니다.
+Stock API MCP Server
+주식 시장 데이터를 제공하는 MCP 서버입니다. (Finnhub + yfinance)
 """
 
 import sys
@@ -14,19 +14,19 @@ start_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if start_path not in sys.path:
     sys.path.append(start_path)
 
-from data.finnhub_client import get_finnhub_client
+from data.stock_api_client import get_stock_api_client
 
 # 환경 변수 로드
 load_dotenv()
 
-# API 키 확인 (Optional check as get_finnhub_client handles it, but good for fail-fast)
+# API 키 확인
 API_KEY = os.getenv("FINNHUB_API_KEY")
 
-# Finnhub 클라이언트 초기화 (Singleton)
-finnhub_client = get_finnhub_client()
+# Stock API 클라이언트 초기화 (Singleton)
+stock_client = get_stock_api_client()
 
 # MCP 서버 초기화
-mcp = FastMCP("Finnhub Stock Data")
+mcp = FastMCP("Stock Data API")
 
 
 @mcp.tool()
@@ -34,7 +34,7 @@ def get_stock_quote(symbol: str) -> Dict[str, Any]:
     """
     특정 주식 티커의 실시간 시세 정보를 조회합니다.
     """
-    quote = finnhub_client.get_quote(symbol)
+    quote = stock_client.get_quote(symbol)
     if "error" in quote:
         return {"error": quote["error"], "symbol": symbol}
 
@@ -55,13 +55,13 @@ def get_stock_quote(symbol: str) -> Dict[str, Any]:
 @mcp.tool()
 def get_company_profile(symbol: str) -> Dict[str, Any]:
     """기업의 기본 프로필 정보 조회"""
-    return finnhub_client.get_company_profile(symbol)
+    return stock_client.get_company_profile(symbol)
 
 
 @mcp.tool()
 def get_price_target(symbol: str) -> Dict[str, Any]:
     """애널리스트 목표 주가 조회"""
-    return finnhub_client.get_price_target(symbol)
+    return stock_client.get_price_target(symbol)
 
 
 @mcp.tool()
@@ -70,13 +70,13 @@ def get_company_news(
 ) -> List[Dict[str, Any]]:
     """기업 뉴스 조회 (최근 7일 기본)"""
     # 내부 클라이언트는 to -> to_date 파라미터 사용
-    return finnhub_client.get_company_news(symbol, from_date=from_date, to_date=to)[:5]
+    return stock_client.get_company_news(symbol, from_date=from_date, to_date=to)[:5]
 
 
 @mcp.tool()
 def get_market_news(category: str = "general") -> List[Dict[str, Any]]:
     """시장 전체 뉴스 조회"""
-    return finnhub_client.get_market_news(category)[:5]
+    return stock_client.get_market_news(category)[:5]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## [API] Stock API 리팩토링 및 yfinance fallback 추가

### 📋 변경 배경
Finnhub 무료 플랜에서 `stock/candle`(주가 추이), `stock/price-target`(목표주가) 엔드포인트가 403 Forbidden으로 차단됨. yfinance로 자동 fallback 구현.

### 🔄 변경 사항

#### 1. 파일명/클래스명 변경
| Before | After |
|--------|-------|
| [finnhub_client.py](cci:7://file:///Users/leebyoungjae/Desktop/Workspaces/SKN22-3rd-4Team/src/data/finnhub_client.py:0:0-0:0) | `stock_api_client.py` |
| [finnhub_server.py](cci:7://file:///Users/leebyoungjae/Desktop/Workspaces/SKN22-3rd-4Team/src/tools/finnhub_server.py:0:0-0:0) | `stock_api_server.py` |
| `FinnhubClient` | `StockAPIClient` |
| `get_finnhub_client()` | `get_stock_api_client()` |

#### 2. yfinance Fallback 구현
- `get_candles()`: Finnhub 실패 시 `yfinance.Ticker.history()` 사용
- `get_price_target()`: Finnhub 실패 시 `yfinance.Ticker.info` 사용

#### 3. 하위 호환성 유지
```python
FinnhubClient = StockAPIClient
get_finnhub_client = get_stock_api_client

#### 4. 테스트 결과

=== 캔들 데이터 (yfinance fallback) ===
Finnhub API 403 Forbidden → fallback 성공
Status: ok
Data points: 30
=== 목표주가 (yfinance fallback) ===
Finnhub API 403 Forbidden → fallback 성공
목표가 (평균): 287.29